### PR TITLE
Add pin replies option in tools menu

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -5,6 +5,11 @@
         <span class="menu-icon"><i class="fa fa-fw fa-pencil"></i></span> [[topic:edit]]
     </a>
 </li>
+<li>
+    <a component="post/pin" role="menuitem" tabindex="-1" href="#">
+        <span class="menu-icon"><i class="fa fa-fw fa-chevron-up"></i></span> Pin
+    </a>
+</li>
 <li <!-- IF posts.deleted -->hidden<!-- ENDIF posts.deleted -->>
     <a component="post/delete" role="menuitem" tabindex="-1" href="#" class="<!-- IF posts.deleted -->hidden<!-- ENDIF posts.deleted -->">
         <div class="inline menu-icon"><i class="fa fa-fw fa-trash-o"></i></div> <span>[[topic:delete]]</span>

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -6,10 +6,16 @@
     </a>
 </li>
 <li>
-    <a component="post/pin" role="menuitem" tabindex="-1" href="#">
+    <a component="topic/pin" role="menuitem" tabindex="-1" href="#">
         <span class="menu-icon"><i class="fa fa-fw fa-chevron-up"></i></span> Pin
     </a>
 </li>
+
+<!-- IF privileges.editable -->
+<li <!-- IF pinned -->hidden<!-- ENDIF pinned -->><a component="topic/pin" href="#" class="<!-- IF pinned -->hidden<!-- ENDIF pinned -->"><i class="fa fa-fw fa-thumb-tack"></i> [[topic:thread_tools.pin]]</a></li>
+<li <!-- IF !pinned -->hidden<!-- ENDIF !pinned -->><a component="topic/unpin" href="#" class="<!-- IF !pinned -->hidden<!-- ENDIF !pinned -->"><i class="fa fa-fw fa-thumb-tack fa-rotate-90"></i> [[topic:thread_tools.unpin]]</a></li>
+<!-- ENDIF privileges.editable -->
+
 <li <!-- IF posts.deleted -->hidden<!-- ENDIF posts.deleted -->>
     <a component="post/delete" role="menuitem" tabindex="-1" href="#" class="<!-- IF posts.deleted -->hidden<!-- ENDIF posts.deleted -->">
         <div class="inline menu-icon"><i class="fa fa-fw fa-trash-o"></i></div> <span>[[topic:delete]]</span>


### PR DESCRIPTION
I added a Pin option in the topic reply's tools menu. After you click on the three dots in your reply, the tools menu shows up, and the Pin option appears under the Edit option. When you click on the Pin option, a pop-up window for the administrator to set the end date of pinning of the reply appears.

I modified the themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl file to include a Pin option. I refered to the topic-pin function in themes/nodebb-theme-persona/templates/partials/topic/topic-menu-list.tpl to include a pop-up window for the administrator to set the end date of pinning of the reply whenever the Pin option is selected.

This is the front-end implementation of issue #4. Needs further back-end support. 