### PR TITLE
Installed JSHint Static Tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
         "grunt-contrib-watch": "1.1.0",
         "husky": "8.0.2",
         "jsdom": "20.0.3",
+        "jshint": "^2.13.6",
         "lint-staged": "13.1.0",
         "mocha": "10.2.0",
         "mocha-lcov-reporter": "1.3.0",


### PR DESCRIPTION
Resolves #23 

- Installed JSHint, a static analysis tool that flags "suspicious" usage in JavaScript programs
- Tested using NodeBB files
- Sample: the following output message is generated after running `./jshint /src/admin/versions.js`


<img width="1081" alt="Screen Shot 2023-03-17 at 10 58 17 PM" src="https://user-images.githubusercontent.com/18632139/226080992-8f0cf167-8a00-4cc1-9b58-85a25b18b991.png">

